### PR TITLE
try fix entrypoint error

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -8,7 +8,6 @@ LABEL com.github.containers.toolbox="true" \
 # `distrobox-host-exec` will detect that it has been symlinked to
 # and it will execute the linking program on the host machine.
 RUN \
-    ln -fs /bin/sh /usr/bin/sh && \
     ln -fs /usr/bin/distrobox-host-exec /usr/local/bin/flatpak && \
     ln -fs /usr/bin/distrobox-host-exec /usr/local/bin/podman && \
     ln -fs /usr/bin/distrobox-host-exec /usr/local/bin/rpm-ostree

--- a/README.md
+++ b/README.md
@@ -4,7 +4,11 @@ Container image for my dev workspace.
 
 ## Usage
 
-tbd
+Run
+
+```bash
+distrobox create --image ghcr.io/apatel762/workspace workspace
+```
 
 ## Verification
 


### PR DESCRIPTION
 Error: could not start entrypoint.
{"msg":"exec container process `/usr/bin/entrypoint`: Too many levels of symbolic links","level":"error","time":"2024-04-14T17:02:49.510678Z"}